### PR TITLE
Fix duplicate PTP messages when tracing/smpi/internals is enabled

### DIFF
--- a/src/smpi/smpi_pmpi.c
+++ b/src/smpi/smpi_pmpi.c
@@ -1171,7 +1171,9 @@ int PMPI_Recv(void *buf, int count, MPI_Datatype datatype, int src, int tag,
   //the src may not have been known at the beginning of the recv (MPI_ANY_SOURCE)
   if(status!=MPI_STATUS_IGNORE){
     src_traced = smpi_group_index(smpi_comm_group(comm), status->MPI_SOURCE);
-    TRACE_smpi_recv(rank, src_traced, rank);
+    if (!TRACE_smpi_view_internals()) {
+      TRACE_smpi_recv(rank, src_traced, rank);
+    }
   }
   TRACE_smpi_ptp_out(rank, src_traced, rank, __FUNCTION__);
   }
@@ -1216,7 +1218,9 @@ int PMPI_Send(void *buf, int count, MPI_Datatype datatype, int dst, int tag,
     dt_size_send = smpi_datatype_size(datatype);
   extra->send_size = count*dt_size_send;
   TRACE_smpi_ptp_in(rank, rank, dst_traced, __FUNCTION__, extra);
-  TRACE_smpi_send(rank, rank, dst_traced,count*smpi_datatype_size(datatype));
+  if (!TRACE_smpi_view_internals()) {
+    TRACE_smpi_send(rank, rank, dst_traced,count*smpi_datatype_size(datatype));
+  }
 
     smpi_mpi_send(buf, count, datatype, dst, tag, comm);
     retval = MPI_SUCCESS;

--- a/src/smpi/smpi_replay.c
+++ b/src/smpi/smpi_replay.c
@@ -263,7 +263,9 @@ static void action_send(const char *const *action)
   extra->dst = dst_traced;
   extra->datatype1 = encode_datatype(MPI_CURRENT_TYPE, NULL);
   TRACE_smpi_ptp_in(rank, rank, dst_traced, __FUNCTION__, extra);
-  TRACE_smpi_send(rank, rank, dst_traced, size*smpi_datatype_size(MPI_CURRENT_TYPE));
+  if (!TRACE_smpi_view_internals()) {
+    TRACE_smpi_send(rank, rank, dst_traced, size*smpi_datatype_size(MPI_CURRENT_TYPE));
+  }
 
   smpi_mpi_send(NULL, size, MPI_CURRENT_TYPE, to , 0, MPI_COMM_WORLD);
 
@@ -292,7 +294,9 @@ static void action_Isend(const char *const *action)
   extra->dst = dst_traced;
   extra->datatype1 = encode_datatype(MPI_CURRENT_TYPE, NULL);
   TRACE_smpi_ptp_in(rank, rank, dst_traced, __FUNCTION__, extra);
-  TRACE_smpi_send(rank, rank, dst_traced, size*smpi_datatype_size(MPI_CURRENT_TYPE));
+  if (!TRACE_smpi_view_internals()) {
+    TRACE_smpi_send(rank, rank, dst_traced, size*smpi_datatype_size(MPI_CURRENT_TYPE));
+  }
 
   request = smpi_mpi_isend(NULL, size, MPI_CURRENT_TYPE, to, 0,MPI_COMM_WORLD);
 
@@ -334,7 +338,9 @@ static void action_recv(const char *const *action) {
   smpi_mpi_recv(NULL, size, MPI_CURRENT_TYPE, from, 0, MPI_COMM_WORLD, &status);
 
   TRACE_smpi_ptp_out(rank, src_traced, rank, __FUNCTION__);
-  TRACE_smpi_recv(rank, src_traced, rank);
+  if (!TRACE_smpi_view_internals()) {
+    TRACE_smpi_recv(rank, src_traced, rank);
+  }
 
   log_timed_action (action, clock);
 }


### PR DESCRIPTION
When the tracing/smpi/internals option is not enabled, some PTP messages
are showed for send and receive operations, both on tracing and
replaying. When the option is enabled, additional messages are
generated, so duplicate messages for send and receive operations
appear on the log.

Initially I thought that the idea was to only show PTP messages when the
tracing/smpi/internals option is enabled. After talking to Arnaud it
seems that is not the case. So I changed the code so both funcionalities
are present: PTP messages for send and receive operations when the
option is disabled and all PTP messages when the option is enabled, as
expected.

I have little knowledge about the internals of the Simgrid code, this fix was
what worked for me in my experiments. It is possible that this is not the ideal
way to fix this.