### PR TITLE
Allows the bytes_amount argument of MSG_parallel_task_create to be null

### DIFF
--- a/src/simix/libsmx.cpp
+++ b/src/simix/libsmx.cpp
@@ -155,11 +155,13 @@ smx_synchro_t simcall_process_parallel_execute(const char *name,
   int i,j;
   /* checking for infinite values */
   for (i = 0 ; i < host_nb ; ++i) {
-     xbt_assert(std::isfinite(flops_amount[i]), "flops_amount[%d] is not finite!", i);
-     for (j = 0 ; j < host_nb ; ++j) {
+    xbt_assert(std::isfinite(flops_amount[i]), "flops_amount[%d] is not finite!", i);
+    if (bytes_amount != NULL) {
+      for (j = 0 ; j < host_nb ; ++j) {
         xbt_assert(std::isfinite(bytes_amount[i + host_nb * j]),
-             "bytes_amount[%d+%d*%d] is not finite!", i, host_nb, j);
-     }
+                   "bytes_amount[%d+%d*%d] is not finite!", i, host_nb, j);
+      }
+    }
   }
 
   xbt_assert(std::isfinite(amount), "amount is not finite!");

--- a/src/surf/host_ptask_L07.cpp
+++ b/src/surf/host_ptask_L07.cpp
@@ -209,23 +209,25 @@ L07Action::L07Action(Model *model, int host_nb,
 	  this->p_netcardList->push_back(host_list[i]->pimpl_netcard);
 
   /* Compute the number of affected resources... */
-  for (int i = 0; i < host_nb; i++) {
-    for (int j = 0; j < host_nb; j++) {
-      xbt_dynar_t route=NULL;
+  if(bytes_amount != NULL) {
+    for (int i = 0; i < host_nb; i++) {
+      for (int j = 0; j < host_nb; j++) {
+        xbt_dynar_t route=NULL;
 
-      if (bytes_amount[i * host_nb + j] > 0) {
-        double lat=0.0;
-        unsigned int cpt;
-        void *_link;
-        LinkL07 *link;
+        if (bytes_amount[i * host_nb + j] > 0) {
+          double lat=0.0;
+          unsigned int cpt;
+          void *_link;
+          LinkL07 *link;
 
-        routing_platf->getRouteAndLatency((*this->p_netcardList)[i], (*this->p_netcardList)[j],
-        		                          &route, &lat);
-        latency = MAX(latency, lat);
+          routing_platf->getRouteAndLatency((*this->p_netcardList)[i], (*this->p_netcardList)[j],
+                                                        &route, &lat);
+          latency = MAX(latency, lat);
 
-        xbt_dynar_foreach(route, cpt, _link) {
-           link = static_cast<LinkL07*>(_link);
-           xbt_dict_set(ptask_parallel_task_link_set, link->getName(), link, NULL);
+          xbt_dynar_foreach(route, cpt, _link) {
+            link = static_cast<LinkL07*>(_link);
+            xbt_dict_set(ptask_parallel_task_link_set, link->getName(), link, NULL);
+          }
         }
       }
     }
@@ -257,22 +259,23 @@ L07Action::L07Action(Model *model, int host_nb,
     	       host_list[i]->pimpl_cpu->getConstraint(),
                this->getVariable(), flops_amount[i]);
 
-  for (int i = 0; i < host_nb; i++) {
-    for (int j = 0; j < host_nb; j++) {
-      void *_link;
+  if(bytes_amount != NULL) {
+    for (int i = 0; i < host_nb; i++) {
+      for (int j = 0; j < host_nb; j++) {
+        void *_link;
 
-      xbt_dynar_t route=NULL;
-      if (bytes_amount[i * host_nb + j] == 0.0)
-        continue;
+        xbt_dynar_t route=NULL;
+        if (bytes_amount[i * host_nb + j] == 0.0)
+          continue;
 
-      routing_platf->getRouteAndLatency((*this->p_netcardList)[i], (*this->p_netcardList)[j],
-    		                            &route, NULL);
+        routing_platf->getRouteAndLatency((*this->p_netcardList)[i], (*this->p_netcardList)[j],
+                                                    &route, NULL);
 
-      xbt_dynar_foreach(route, cpt, _link) {
-        LinkL07 *link = static_cast<LinkL07*>(_link);
-        lmm_expand_add(model->getMaxminSystem(), link->getConstraint(),
-                       this->getVariable(),
-                       bytes_amount[i * host_nb + j]);
+        xbt_dynar_foreach(route, cpt, _link) {
+          LinkL07 *link = static_cast<LinkL07*>(_link);
+          lmm_expand_add(model->getMaxminSystem(), link->getConstraint(),
+                        this->getVariable(), bytes_amount[i * host_nb + j]);
+        }
       }
     }
   }
@@ -568,7 +571,8 @@ void LinkL07::updateLatency(double value, double date)
  **********/
 
 L07Action::~L07Action(){
-  free(p_communicationAmount);
+  if (p_communicationAmount != NULL)
+    free(p_communicationAmount);
   free(p_computationAmount);
 }
 
@@ -580,16 +584,18 @@ void L07Action::updateBound()
 
   int hostNb = p_netcardList->size();
 
-  for (i = 0; i < hostNb; i++) {
-    for (j = 0; j < hostNb; j++) {
-      xbt_dynar_t route=NULL;
+  if (p_communicationAmount != NULL) {
+    for (i = 0; i < hostNb; i++) {
+      for (j = 0; j < hostNb; j++) {
+        xbt_dynar_t route=NULL;
 
-      if (p_communicationAmount[i * hostNb + j] > 0) {
-        double lat = 0.0;
-        routing_platf->getRouteAndLatency((*p_netcardList)[i], (*p_netcardList)[j],
-                				          &route, &lat);
+        if (p_communicationAmount[i * hostNb + j] > 0) {
+          double lat = 0.0;
+          routing_platf->getRouteAndLatency((*p_netcardList)[i], (*p_netcardList)[j],
+                                                                &route, &lat);
 
-        lat_current = MAX(lat_current, lat * p_communicationAmount[i * hostNb + j]);
+          lat_current = MAX(lat_current, lat * p_communicationAmount[i * hostNb + j]);
+        }
       }
     }
   }


### PR DESCRIPTION
If there is no communications in your parallel task, it is useless to allocate a host_nb*host_nb full of 0.