### PR TITLE
Adding concurrency to SURF LMM, with oldstyle element set

### DIFF
--- a/src/surf/network_cm02.cpp
+++ b/src/surf/network_cm02.cpp
@@ -374,7 +374,6 @@ Action *NetworkCm02Model::communicate(NetCard *src, NetCard *dst,
         break;
       }
     }
-    lmm_variable_concurrency_share_set(action->getVariable(),2);
   }
 
   action = new NetworkCm02Action(this, size, failed);
@@ -451,6 +450,7 @@ Action *NetworkCm02Model::communicate(NetCard *src, NetCard *dst,
       link = static_cast<NetworkCm02Link*>(_link);
       lmm_expand(p_maxminSystem, link->getConstraint(), action->getVariable(), .05);
     }
+    lmm_variable_concurrency_share_set(action->getVariable(),2);
   }
 
   xbt_dynar_free(&route);

--- a/src/surf/network_cm02.cpp
+++ b/src/surf/network_cm02.cpp
@@ -374,6 +374,7 @@ Action *NetworkCm02Model::communicate(NetCard *src, NetCard *dst,
         break;
       }
     }
+    lmm_variable_concurrency_share_set(action->getVariable(),2);
   }
 
   action = new NetworkCm02Action(this, size, failed);


### PR DESCRIPTION
Modification to the SURF LMM:
-> Enabling concurrency control and monitoring 
-> Improving efficiency of lmm_update_modified_set
-> Removing  dead code and adding comments 