### PR TITLE
Energy plugin does not work with <peer>s

### DIFF
--- a/src/surf/plugins/energy.cpp
+++ b/src/surf/plugins/energy.cpp
@@ -235,9 +235,12 @@ static void onHostDestruction(simgrid::s4u::Host& host) {
   if (dynamic_cast<simgrid::surf::VirtualMachine*>(surf_host))
     return;
   HostEnergy *host_energy = host.extension<HostEnergy>();
-  host_energy->update();
-  XBT_INFO("Total energy of host %s: %f Joules",
-    host.name().c_str(), host_energy->getConsumedEnergy());
+  if (host_energy != nullptr)
+  {
+    host_energy->update();
+    XBT_INFO("Total energy of host %s: %f Joules",
+             host.name().c_str(), host_energy->getConsumedEnergy());
+  }
 }
 
 /* **************************** Public interface *************************** */


### PR DESCRIPTION
Our simulator crashed after the main function termination,
which was caused by the function onHostDestruction in the
Simgrid energy plugin calling host_energy->update()
whereas host_energy was null.

This commit simply adds a test about host_energy
not being null before using it in function
onHostDestruction of src/surf/plugins/energy.cpp.

I think this commit shouldn't generate any warnings
nor break any tests. I compiled it under clang 3.7.1
without any warnings and the tests which failed are the
same as in the previous commit.

```
The following tests FAILED:
     73 - msg-file (Failed)
     74 - msg-storage (Failed)
     75 - msg-remote-io (Failed)
    509 - smpi-energy-f77-thread (Failed)
    510 - smpi-energy-f77-ucontext (Failed)
    511 - smpi-energy-f77-raw (Failed)
    512 - smpi-energy-f77-boost (Failed)
    513 - smpi-energy-f90-thread (Failed)
    514 - smpi-energy-f90-ucontext (Failed)
    515 - smpi-energy-f90-raw (Failed)
    516 - smpi-energy-f90-boost (Failed)
```